### PR TITLE
Misc operational updates

### DIFF
--- a/lib/authentication/index.ts
+++ b/lib/authentication/index.ts
@@ -1,4 +1,4 @@
-import { CfnOutput, SecretValue, Duration } from "aws-cdk-lib";
+import { CfnOutput, Duration, RemovalPolicy } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
@@ -45,6 +45,7 @@ export class Cognito extends Construct {
         requireUppercase: true, // Require at least one uppercase letter in password
         tempPasswordValidity: Duration.days(3),
       },
+      removalPolicy: RemovalPolicy.DESTROY, // Destroy when the stack is deleted
     });
 
     // Create a new Cognito User Pool Client for the application

--- a/lib/custom/index.ts
+++ b/lib/custom/index.ts
@@ -21,7 +21,7 @@ export class CustomResources extends Construct {
     const getCloudFrontPrefixList = new lambda.Function(this, 'getCloudFrontPrefixList', {
       code: lambda.Code.fromAsset("./custom_resources/lambda/cloudFront_get_prefix_list"),
       handler: 'cloudFront_get_prefix_list.handler',
-      runtime: lambda.Runtime.PYTHON_3_12,
+      runtime: lambda.Runtime.PYTHON_3_13,
       timeout: Duration.seconds(300),
       memorySize: 128,
       logGroup: new logs.LogGroup(this,  `${props.prefix}getCloudFrontPrefixListLogs`, {

--- a/lib/ecs/index.ts
+++ b/lib/ecs/index.ts
@@ -1,4 +1,4 @@
-import { Duration } from "aws-cdk-lib";
+import { Duration, Stack } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as ecs from "aws-cdk-lib/aws-ecs";
@@ -55,7 +55,10 @@ export class ecsApplication extends Construct {
     });
 
     // Create an ECS cluster
-    const ecsCluster = new ecs.Cluster(this, "FoundationalLlmChatCluster", { vpc: props.vpc });
+    const ecsCluster = new ecs.Cluster(this, "FoundationalLlmChatCluster", {
+      containerInsightsV2: ecs.ContainerInsights.ENHANCED,
+      vpc: props.vpc
+    });
 
     // Create a Fargate service and configure it with the Docker image, environment variables, and other settings
     this.service = new ecsPatterns.ApplicationLoadBalancedFargateService(this, "FoundationalLlmChatService", {
@@ -68,7 +71,7 @@ export class ecsApplication extends Construct {
           logRetention: logs.RetentionDays.FIVE_DAYS
         }),
         environment: {
-          AWS_REGION: props.region ? props.region : "us-west-2",
+          AWS_REGION: props.region ? props.region : Stack.of(this).region,
         },
         secrets: {
           OAUTH_COGNITO_CLIENT_SECRET: ecs.Secret.fromSecretsManager(props.oauth_cognito_client_secret),

--- a/lib/ecs/index.ts
+++ b/lib/ecs/index.ts
@@ -40,6 +40,8 @@ export class ecsApplication extends Construct {
   constructor(scope: Construct, id: string, props: ecsApplicationProps) {
     super(scope, id);
 
+    const containerEnvRegion = props.region || "us-west-2";
+
     // Store the client secret
     const authCodeSecret = new secretsmanager.Secret(this, "authCodeChainlitSecret", {
       secretName: `${props.prefix}chainlit_auth_secret`,
@@ -71,7 +73,7 @@ export class ecsApplication extends Construct {
           logRetention: logs.RetentionDays.FIVE_DAYS
         }),
         environment: {
-          AWS_REGION: props.region ? props.region : Stack.of(this).region,
+          AWS_REGION: containerEnvRegion,
         },
         secrets: {
           OAUTH_COGNITO_CLIENT_SECRET: ecs.Secret.fromSecretsManager(props.oauth_cognito_client_secret),
@@ -131,7 +133,7 @@ export class ecsApplication extends Construct {
 
     // Generate the resource ARNs
     const resourceArns = Object.values(props.bedrockModels).flatMap(model =>
-      generateArns(model, props.region || "us-west-2", props.accountId || "*")
+      generateArns(model, containerEnvRegion, props.accountId || "*")
     );
 
     // Allow the ECS task to call the Bedrock API


### PR DESCRIPTION
**Issue #, if available:** #6

**Description of changes:**

Sharing some proposed updates from my initial experimentation with the sample:

- Clean up the Cognito User Pool on stack destroy as reported in #6 
- Reduce CDK Nag solution check failures by:
    - Updating the Python custom resource Lambda runtime to latest
    - Enabling ECS Container Insights v2
- Consolidate the default region inference in `ecsApplication` to a single place
    - ❓Question: Shouldn't the ideal behaviour be that the region is inferred from current stack deployment target region, with option to override to a different one? These components seem to assume `us-west-2` by default which I can see the reasoning behind but seems a bit counter-intuitive.

As I say I'm fairly new to the solution, so very happy for feedback!

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
