### PR TITLE
Auto-generate Cognito domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The application is configured through a `config.json` file in the `./bin` folder
 
 5. **`prefix`**: This field allows you to set a prefix for resource names created by the application. You can leave it empty or provide a custom prefix if desired.
 
-6. **`cognito_domain`**: This field allows you to specify an already existent cognito domain name. It is _optional_ and in the first deployement is expected to not be defined. See FAQ section for the reason of this parameter existance.
+6. **`cognito_domain`**: This field allows you to _optionally_ specify a pre-existing [Cognito domain name](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-assign-domain.html). If left blank (by default) a new domain will be generated for you automatically.
 
 ### Model Configuration
 

--- a/bin/config.json
+++ b/bin/config.json
@@ -1,6 +1,6 @@
 {
   "default_system_prompt": "You are an assistant",
-  "cognito_domain": "SEE THE README, BUT FOR THE FIRST RUN THISIS AN EMPTY STRING",
+  "cognito_domain": "",
   "max_characters_parameter": "None",
   "max_content_size_mb_parameter": "None",
   "default_aws_region": "us-west-2",


### PR DESCRIPTION
**Issue #, if available:** #9

**Description of changes:**

Remove the requirement for users to manually-configure Cognito domain in 2nd+ deployment, by automatically generating a globally-unique but repeatable domain name prefix in CDK.

As noted in the code comments, this approach is inspired by the globally-unique name generation tools that CDK itself uses for automatically naming resources that raw CloudFormation needs to be explicit.

Originally authored a few months ago and has seemed to work well for us - sorry it took so long to upstream! 😭

**What it means for existing users:**

I *think* users with existing deployments can (and should) leave their `cognito_domain` set as-is in their config.json - since the new auto-generated value will not match what got created before. However, new deployments should be able to start with the field blank *and leave it blank* for stack updates.


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
